### PR TITLE
Reduce attack surface and size for Docker image

### DIFF
--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -24,7 +24,7 @@ RUN set -ex; \
     esac; \
     apt-get update \
     && if [ "$ASSET" = "ce" ] ; then \
-      apt-get install -y curl \
+      apt-get install -y --no-install-recommends curl ca-certificates \
       && UBUNTU_CODENAME=$(cat /etc/os-release | grep UBUNTU_CODENAME | cut -d = -f 2) \
       && curl -fL https://download.konghq.com/gateway-${KONG_VERSION%%.*}.x-ubuntu-${UBUNTU_CODENAME}/pool/all/k/kong/kong_${KONG_VERSION}_$arch.deb -o /tmp/kong.deb \
       && apt-get purge -y curl \
@@ -38,7 +38,7 @@ RUN set -ex; \
     # Please update the ubuntu install docs if the below line is changed so that
     # end users can properly install Kong along with its required dependencies
     # and that our CI does not diverge from our docs.
-    && apt install --yes /tmp/kong.deb \
+    && apt install --yes --no-install-recommends /tmp/kong.deb \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /tmp/kong.deb \
     && chown kong:0 /usr/local/bin/kong \


### PR DESCRIPTION
Hi,

This pull request includes several small improvements for the Dockerfile, which should help improve the security of container and reduce the risk of potential attacks.

The following changes have been made:
- I added `--no-install-recommends` to remove unnecessary `apt` packages, that were not needed for the container's functionality. This change not only trims your image size but also can also reduce the attack surface.
- `ca-certificates` was added because it was needed for the `curl` command.

I hope that you find them useful. Please let me know if you have any concerns.

Thank you.